### PR TITLE
chore: Run build on pull requests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: packwatch CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   lint:
@@ -34,7 +34,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
-  
+
   build:
     runs-on: ubuntu-latest
     needs: test


### PR DESCRIPTION
Seems like the push event only applies to repository branches https://help.github.com/en/actions/reference/events-that-trigger-workflows#push-event-push, I suspect that the pull_request event is needed to run the build on branches of forks.

UPDATE: confirmed by the fact that it's building this PR 😅 